### PR TITLE
Offload flake input downloads to the recursive derivation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,21 @@
       }
     },
     "flake-compat": {
+      "locked": {
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "owner": "enobayram",
+        "repo": "flake-compat",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "enobayram",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -66,7 +81,7 @@
         "cardano-shell": [
           "empty"
         ],
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "ghc-8.6.5-iohk": [
           "empty"
         ],
@@ -194,6 +209,7 @@
     "root": {
       "inputs": {
         "empty": "empty",
+        "flake-compat": "flake-compat",
         "hackage": "hackage",
         "haskellNix": "haskellNix",
         "nixpkgs": "nixpkgs"

--- a/flake.lock
+++ b/flake.lock
@@ -20,13 +20,13 @@
       "locked": {
         "lastModified": 1699384378,
         "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
-        "owner": "enobayram",
+        "owner": "kadena-io",
         "repo": "flake-compat",
         "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
         "type": "github"
       },
       "original": {
-        "owner": "enobayram",
+        "owner": "kadena-io",
         "repo": "flake-compat",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1699390864,
-        "narHash": "sha256-MWSuUZWZRYI8CAKbU/NhjNy22FSOuUZ9SsdwSW5N07o=",
+        "lastModified": 1699384378,
+        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
         "owner": "enobayram",
         "repo": "flake-compat",
-        "rev": "0b84b577d4a337421ff7b014b99cbf464d211fb3",
+        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
         "type": "github"
       },
       "original": {
@@ -190,6 +190,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-rec": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1695318763,
@@ -212,7 +228,8 @@
         "flake-compat": "flake-compat",
         "hackage": "hackage",
         "haskellNix": "haskellNix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-rec": "nixpkgs-rec"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1699390179,
-        "narHash": "sha256-tWx/Y8O0xq8T/YNZUichaKVO2jOZSOSoiFLQLZHi9BI=",
+        "lastModified": 1699390864,
+        "narHash": "sha256-MWSuUZWZRYI8CAKbU/NhjNy22FSOuUZ9SsdwSW5N07o=",
         "owner": "enobayram",
         "repo": "flake-compat",
-        "rev": "3a9e1d04df57bd541b561799531431b2a2ba67e3",
+        "rev": "0b84b577d4a337421ff7b014b99cbf464d211fb3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1699384378,
-        "narHash": "sha256-jI0nYllONVrNnyOYrvQMIEJQJuNeKnfJo5keRxWMcWs=",
+        "lastModified": 1699390179,
+        "narHash": "sha256-tWx/Y8O0xq8T/YNZUichaKVO2jOZSOSoiFLQLZHi9BI=",
         "owner": "enobayram",
         "repo": "flake-compat",
-        "rev": "6ef9397736efb0f6075188aa3488022d1b85c11d",
+        "rev": "3a9e1d04df57bd541b561799531431b2a2ba67e3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
       url = "github:input-output-hk/hackage.nix";
       flake = false;
     };
-    flake-compat.follows = "haskellNix/flake-compat";
+    flake-compat.url = "github:enobayram/flake-compat";
     haskellNix = {
       url = "github:input-output-hk/haskell.nix";
       inputs = {
@@ -59,7 +59,7 @@
           requiredSystemFeatures = [ "recursive-nix" ] ++ env.requiredSystemFeatures or [];
           FLAKEDEPS = let
             # This function doesn't support building a flake with overridden inputs.
-            rawFlakeInputs = (import inputs.flake-compat { src = "${flake}"; }).defaultNix.inputs;
+            rawFlakeInputs = (import inputs.flake-compat { src = "${flake}"; fetchTarball = pkgs.fetchzip; }).defaultNix.inputs;
             deps = recursiveDeps rawFlakeInputs;
             depName = dep: "DEP-${builtins.concatStringsSep "/" dep.inputPath}";
             env = builtins.listToAttrs

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,9 @@
       url = "github:input-output-hk/hackage.nix";
       flake = false;
     };
-    flake-compat.url = "github:enobayram/flake-compat";
+    # This version of flake-compat allows us to replace fetchTarball with fetchzip
+    # We can revert to upstream once https://github.com/edolstra/flake-compat/pull/62 is in
+    flake-compat.url = "github:kadena-io/flake-compat";
     nixpkgs-rec.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
     haskellNix = {
       url = "github:input-output-hk/haskell.nix";


### PR DESCRIPTION
This PR revamps the recursive build utility provided by this flake. Previously, we were using the `inputs` of the flake object, but the problem was that the dependency tree of a flake is created in such a way that referring to the flakes inside perform the download at Nix evaluation time. That meant that while trying to construct the recursive derivation, we were already downloading them, defeating the whole purpose of reducing the nix evaluation time dependencies.

With this PR, we're pushing the fetching of those dependencies into the recursive derivation using a modified version of `flake-compat` that uses `pkgs.fetchzip` to do the fetch. This is different from building the flake directly with `nix build` or using vanilla `flake-compat` inside the recursive derivation, because then Nix tries to fetch the inputs at nix eval time and fails to perform the download. `pkgs.fetchzip` offloads the downloads to individual derivations, which works fine inside the recursive derivation since then the download gets performed by a regular builder outside the recursive-nix derivation.