### PR TITLE
Introduce wrapRecursiveWithMeta

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -165,9 +165,10 @@
 
              # Meant to be used by CI jobs for triggering the build (and cache) of
              # all recursive-nix derivations.
-             showDerivations = ''
-               ${name} = ${recursiveDeriv}
-               ${name}-meta = ${recursiveMeta}
+             allDerivations = pkgs-rec.runCommand "${name}-all-derivations" {} ''
+               echo ${recursiveDeriv}
+               echo ${recursiveMeta}
+               echo OK > $out
              '';
            };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,10 @@
     # Utilities for building flake outputs inside recursive-nix derivations
     lib.recursive = system: rec {
 
+      # We're exposing the pkgs we use for constructing the recursive derivations so
+      # that the downstream flakes can reuse it. This is important, because any nixpkgs
+      # version that gets referenced in the outer layer will have to be fetched by
+      # clients even if the results are in the cache.
       pkgs-rec = inputs.nixpkgs-rec.legacyPackages.${system};
 
       # runRecursiveBuild is a variant of pkgs.runCommand that sets up a recursive-nix

--- a/flake.nix
+++ b/flake.nix
@@ -162,6 +162,13 @@
                meta = cachedMeta.meta or null;
              };
              metaDrv = recursiveMeta;
+
+             # Meant to be used by CI jobs for triggering the build (and cache) of
+             # all recursive-nix derivations.
+             showDerivations = ''
+               ${name} = ${recursiveDeriv}
+               ${name}-meta = ${recursiveMeta}
+             '';
            };
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -159,8 +159,9 @@
                 EOF
                 echo $out
                 cp $(nix-build default.nix -A meta) $out/meta.json
-                ln -s $(nix-build default.nix -A paths) $out/paths
-                cp $(nix-build default.nix -A meta) $out
+
+                mkdir $out/paths
+                cp -P $(nix-build default.nix -A paths)/* $out/paths
               '';
             cachedMeta = builtins.fromJSON (builtins.readFile "${recursiveMeta}/meta.json");
             cachedPaths = builtins.mapAttrs


### PR DESCRIPTION
This PR introduces a higher-order recursive-nix utility called `wrapRecursiveWithMeta`.

`wrapRecursiveWithMeta` allows the caller to wrap a Nix derivation inside a recursive layer and also propagates some metadata through a side-channel, which is also a recursive derivation, and is therefore subject to caching.

In order to use `wrapRecursiveWithMeta` effectively, callers need to use the other utilities in tandem, that's why this PR also reorganizes the `recursive` utilities so that they can me conveniently accessed with:

```
with hs-nix-infra.lib.recursive system; 
```
