### PR TITLE
Bump hs-nix-infra for ghc964

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -266,16 +266,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707891787,
-        "narHash": "sha256-ksxxr4lfZ3iGO6qb1LcOlOFe/tzZ1pBCkHDar8FH3PM=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "647b06d51cca7a502d27a206d7454b5a8e0a1545",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -166,16 +166,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1707785367,
-        "narHash": "sha256-VktXMQCZww+rD4lpJz/8sieynjrdADAbpNEyTEGSnbg=",
+        "lastModified": 1707868680,
+        "narHash": "sha256-LvSBLnqPRPr50qFHp8D//jcv509CMKrsh/d2drF7HV4=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "42990599ce04d78904cc01fc91b4f0b834644dad",
+        "rev": "042613a44e0f1d838e206f924213e237a2d06677",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "rev": "042613a44e0f1d838e206f924213e237a2d06677",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -48,25 +48,6 @@
         "type": "github"
       }
     },
-    "ghc98X": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696643148,
-        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
-        "ref": "ghc-9.8",
-        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
-        "revCount": 61642,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.8",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -104,7 +85,9 @@
         "ghc-8.6.5-iohk": [
           "empty"
         ],
-        "ghc98X": "ghc98X",
+        "ghc98X": [
+          "empty"
+        ],
         "ghc99": [
           "empty"
         ],
@@ -120,9 +103,15 @@
         "hls-2.2": [
           "empty"
         ],
-        "hls-2.3": "hls-2.3",
-        "hls-2.4": "hls-2.4",
-        "hls-2.5": "hls-2.5",
+        "hls-2.3": [
+          "empty"
+        ],
+        "hls-2.4": [
+          "empty"
+        ],
+        "hls-2.5": [
+          "empty"
+        ],
         "hls-2.6": "hls-2.6",
         "hpc-coveralls": [
           "empty"
@@ -156,7 +145,9 @@
         "nixpkgs-2305": [
           "empty"
         ],
-        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2311": [
+          "empty"
+        ],
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": [
           "empty"
@@ -176,57 +167,6 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hls-2.3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.3.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699862708,
-        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.4.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701080174,
-        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.5.0.0",
-        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -277,22 +217,6 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2311": {
-      "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -266,17 +266,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669833724,
-        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "lastModified": 1707863367,
+        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,25 @@
         "type": "github"
       }
     },
+    "ghc98X": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696643148,
+        "narHash": "sha256-E02DfgISH7EvvNAu0BHiPvl1E5FGMDi0pWdNZtIBC9I=",
+        "ref": "ghc-9.8",
+        "rev": "443e870d977b1ab6fc05f47a9a17bc49296adbd6",
+        "revCount": 61642,
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      },
+      "original": {
+        "ref": "ghc-9.8",
+        "submodules": true,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
     "hackage": {
       "flake": false,
       "locked": {
@@ -85,9 +104,7 @@
         "ghc-8.6.5-iohk": [
           "empty"
         ],
-        "ghc980": [
-          "empty"
-        ],
+        "ghc98X": "ghc98X",
         "ghc99": [
           "empty"
         ],
@@ -104,6 +121,9 @@
           "empty"
         ],
         "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
         "hpc-coveralls": [
           "empty"
         ],
@@ -113,6 +133,7 @@
         "iserv-proxy": [
           "empty"
         ],
+        "nix-tools-static": "nix-tools-static",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
@@ -135,6 +156,7 @@
         "nixpkgs-2305": [
           "empty"
         ],
+        "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": [
           "empty"
@@ -144,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697195891,
-        "narHash": "sha256-0L803S/wcHmVebEwFxObYCYOaB14ZtBAFCdg0aRgH70=",
+        "lastModified": 1707785367,
+        "narHash": "sha256-VktXMQCZww+rD4lpJz/8sieynjrdADAbpNEyTEGSnbg=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "c6cb3ff56b001b211690da35f70827fab5bf3272",
+        "rev": "42990599ce04d78904cc01fc91b4f0b834644dad",
         "type": "github"
       },
       "original": {
@@ -174,6 +196,74 @@
         "type": "github"
       }
     },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "nix-tools-static": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1706266250,
+        "narHash": "sha256-9t+GRk3eO9muCtKdNAwBtNBZ5dH1xHcnS17WaQyftwA=",
+        "owner": "input-output-hk",
+        "repo": "haskell-nix-example",
+        "rev": "580cb6db546a7777dad3b9c0fa487a366c045c4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "nix",
+        "repo": "haskell-nix-example",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1669833724,
@@ -187,6 +277,22 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1701386440,
+        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -208,17 +314,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1695318763,
-        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
+        "lastModified": 1694822471,
+        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1707783775,
-        "narHash": "sha256-TkNPcAICbowXV5imZnjFrKLWJXp+e8PvEgSXm1WZos0=",
+        "lastModified": 1707870123,
+        "narHash": "sha256-pOvz6uuPYw3CiPgi63QhNYumoKeyzDh9JOkLDngGWsE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3518308dbe3dbc462fc69baf95b3c9acaeb47de4",
+        "rev": "75345eba5d4159e6f54cbdc38785d1e0d0e655e0",
         "type": "github"
       },
       "original": {
@@ -166,17 +166,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1707868680,
-        "narHash": "sha256-LvSBLnqPRPr50qFHp8D//jcv509CMKrsh/d2drF7HV4=",
+        "lastModified": 1707876653,
+        "narHash": "sha256-hsj9chw/cy9h8XuxQkxnfFR22Ek8xEm33aON2+TcUaI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "042613a44e0f1d838e206f924213e237a2d06677",
+        "rev": "d1a608f84c9ed00ceca8571b253e79f67a1ae2d6",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "042613a44e0f1d838e206f924213e237a2d06677",
         "type": "github"
       }
     },
@@ -267,11 +266,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707863367,
-        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
+        "lastModified": 1707891787,
+        "narHash": "sha256-ksxxr4lfZ3iGO6qb1LcOlOFe/tzZ1pBCkHDar8FH3PM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
+        "rev": "647b06d51cca7a502d27a206d7454b5a8e0a1545",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -70,11 +70,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1696379114,
-        "narHash": "sha256-dtax/ci3JfYvR2lLsvpvC6b3NCoEGZLrDH21/2svTps=",
+        "lastModified": 1707783775,
+        "narHash": "sha256-TkNPcAICbowXV5imZnjFrKLWJXp+e8PvEgSXm1WZos0=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "21eae6f46c91831741496101e541e628aadecd98",
+        "rev": "3518308dbe3dbc462fc69baf95b3c9acaeb47de4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,9 @@
         "hls-1.10".follows = "empty";
         "hls-2.0".follows = "empty";
         "hls-2.2".follows = "empty";
+        "hls-2.3".follows = "empty";
+        "hls-2.4".follows = "empty";
+        "hls-2.5".follows = "empty";
         hpc-coveralls.follows = "empty";
         nixpkgs-2003.follows = "empty";
         nixpkgs-2105.follows = "empty";
@@ -41,10 +44,12 @@
         nixpkgs-2205.follows = "empty";
         nixpkgs-2211.follows = "empty";
         nixpkgs-2305.follows = "empty";
+        nixpkgs-2311.follows = "empty";
         old-ghc-nix.follows = "empty";
         iserv-proxy.follows = "empty";
         hydra.follows = "empty";
         ghc980.follows = "empty";
+        ghc98X.follows = "empty";
         ghc99.follows = "empty";
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/47585496bcb13fb72e4a90daeea2f434e2501998";
 
     # We're declaring hackage as a direct input to this flake so that downstream
     # flakes can override it.

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs?rev=4d2b37a84fad1091b9de401eb450aae66f1a741e";
+    nixpkgs.url = "github:NixOS/nixpkgs";
 
     # We're declaring hackage as a direct input to this flake so that downstream
     # flakes can override it.

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       flake = false;
     };
     haskellNix = {
-      url = "github:input-output-hk/haskell.nix";
+      url = "github:input-output-hk/haskell.nix/042613a44e0f1d838e206f924213e237a2d06677";
 
       # This allows downstream flakes to override hackage through this flake
       inputs.hackage.follows = "hackage";

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
       flake = false;
     };
     haskellNix = {
-      url = "github:input-output-hk/haskell.nix/042613a44e0f1d838e206f924213e237a2d06677";
+      url = "github:input-output-hk/haskell.nix";
 
       # This allows downstream flakes to override hackage through this flake
       inputs.hackage.follows = "hackage";


### PR DESCRIPTION
This PR bumps our Haskell toolchain in order to allow Pact to upgrade to `ghc964`. See https://github.com/kadena-io/pact/pull/1326